### PR TITLE
Bump fluent-bit to 3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump fluent-bit from `3.0.6` to `3.1.6`.
+
 ## [0.3.0] - 2024-05-28
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7,linux/s390x" -f ./dockerfiles/Dockerfile.multiarch --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz ./dockerfiles/
 
 # Set this to the current release version: it gets done so as part of the release.
-ARG RELEASE_VERSION=3.0.6
+ARG RELEASE_VERSION=3.1.6
 
 # For multi-arch builds - assumption is running on an AMD64 host
 FROM multiarch/qemu-user-static:x86_64-arm as qemu-arm32

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This mostly rely on the upstream dockerfile with a few changes annotated with `G
 
 ## Upgrade
 
-To upgrade the fluent-bit version, you should go to `./Dockerfile`, bump the value of `ARG RELEASE_VERSION=3.0.6` to the wanted fluent-bit version and create a `Release PR` to trigger the circle CI workflow.
+To upgrade the fluent-bit version, you should go to `./Dockerfile`, bump the value of `ARG RELEASE_VERSION=3.1.6` to the wanted fluent-bit version and create a `Release PR` to trigger the circle CI workflow.


### PR DESCRIPTION
This PR bumps fluent-bit to fix existing CVEs

cc @pipo02mix 